### PR TITLE
Added Biomes to the BiomeDictionary.

### DIFF
--- a/src/main/java/deerangle/treemendous/main/Treemendous.java
+++ b/src/main/java/deerangle/treemendous/main/Treemendous.java
@@ -80,6 +80,7 @@ public class Treemendous {
 
     private void commonSetup(final FMLCommonSetupEvent event) {
         BiomeMaker.addBiomesToOverworld();
+        BiomeMaker.addBiomesToBiomeDictionary();
     }
 
 }

--- a/src/main/java/deerangle/treemendous/world/BiomeMaker.java
+++ b/src/main/java/deerangle/treemendous/world/BiomeMaker.java
@@ -17,6 +17,7 @@ import net.minecraft.world.gen.feature.structure.StructureFeatures;
 import net.minecraft.world.gen.placement.AtSurfaceWithExtraConfig;
 import net.minecraft.world.gen.placement.Placement;
 import net.minecraft.world.gen.surfacebuilders.ConfiguredSurfaceBuilders;
+import net.minecraftforge.common.BiomeDictionary;
 import net.minecraftforge.common.BiomeManager;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -24,6 +25,8 @@ import net.minecraftforge.registries.ForgeRegistries;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static net.minecraftforge.common.BiomeDictionary.Type.*;
 
 public class BiomeMaker {
 
@@ -181,8 +184,23 @@ public class BiomeMaker {
         }
     }
 
+    public static void addBiomesToBiomeDictionary() {
+        BiomeDictionary.addTypes(MIXED_MAPLE_FOREST, OVERWORLD, FOREST);
+        BiomeDictionary.addTypes(MIXED_FOREST, OVERWORLD, FOREST);
+        BiomeDictionary.addTypes(MIXED_FOREST_VANILLA, OVERWORLD, FOREST);
+        BiomeDictionary.addTypes(NEEDLE_FOREST, OVERWORLD, FOREST);
+        BiomeDictionary.addTypes(NEEDLE_FOREST_SNOW, OVERWORLD, FOREST);
+        for (RegisteredTree tree : TreeRegistry.TREES) {
+            for (RegistryKey<Biome> b : tree.getFrostyBiomes()) {
+                BiomeDictionary.addTypes(b, OVERWORLD, FOREST, COLD);
+            }
+            for (RegistryKey<Biome> b : tree.getBiomes()) {
+                BiomeDictionary.addTypes(b, OVERWORLD, FOREST);
+            }
+        }
+    }
+
     public static RegistryKey<Biome> makeBiomeKey(String name) {
         return RegistryKey.getOrCreateKey(Registry.BIOME_KEY, new ResourceLocation(Treemendous.MODID, name));
     }
-
 }


### PR DESCRIPTION
By adding the biomes to the BiomeDictionary, you will increase mod compatibility.

I have attempted to stay close to the source, taking over the way they are currently added to the overworld. Something could be said for combining the two methods into on (so you will loop only once over the trees).

The code could also be adjusted to add more types, where necessary. I didn't add, for example, "HILLS", to the hills variants. Doing this automatically would require some changes in RegisteredTree, probably (splitting the two biomecollections there into a couple more).

For example, mods that add structures to FOREST, will now also appear in treemendous biomes. 
By adding the OVERWORLD BiomeDictionary type, the mod also autiomatically gains compatibility with Terraforged.